### PR TITLE
Refactoring Markdown to consistent format

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -2,25 +2,18 @@
 
 ## What is a "conscious language" effort?
 
-The software industry has fallen in to the habit of using certain
-words, like blacklist, and slave, without giving a lot of thought to the
-emotional baggage that these words carry.
+The software industry has fallen in to the habit of using certain words, like blacklist, and slave, without giving a lot of thought to the emotional baggage that these words carry.
 
-The phrase "conscious language" refers to selecting words and phrases
-consciously, intentionally, considering connotations as well as
-denotations. We encourage projects to choose phrases that clearly
-communicate the technical meaning, without using metaphors or
-colloqualisms.
+The phrase "conscious language" refers to selecting words and phrases consciously, intentionally, considering connotations as well as denotations. We encourage projects to choose phrases that clearly ommunicate the technical meaning, without using metaphors or colloqualisms.
 
-This has the dual meaning of removing problematic terms, and also
-communicating more clearly, particularly to those who are working in a
-secondary language.
+This has the dual meaning of removing problematic terms, and also communicating more clearly, particularly to those who are working in a secondary language.
 
 Our goals are to identify where problematic terms are used, collaborate on replacement terminology, support project contributors in making updates, and report on joint progress.
 
 ## Why is this important?
 
-If open source is truly meant to be inclusive and a place where anyone can participate, it must be welcoming to all. If words or phrases convey secondary unintended meanings to our audience, we are choosing to limit participation in our projects, which is antithetical to this goal.
+If open source is truly meant to be inclusive and a place where anyone can participate, it must be welcoming to all.
+If words or phrases convey secondary unintended meanings to our audience, we are choosing to limit participation in our projects, which is antithetical to this goal.
 
 ## What terms are we recommending you consider?
 
@@ -30,9 +23,12 @@ Over time, we may recommend consideration of other terms, such as words that ref
 
 ## What are the recommended replacement terms?
 
-To proceed, teams should follow the [recommendations outlined by the Linux kernel](https://lkml.org/lkml/2020/7/4/229). These recommendations have informed the terminology recommendations we provide below. 
+To proceed, teams should follow the [recommendations outlined by the Linux kernel](https://lkml.org/lkml/2020/7/4/229).
+These recommendations have informed the terminology recommendations we provide below. 
 
-To ensure consistency and success, it is imperative for product team stakeholders to align internally. For example, documentation teams should engage in discussions with their engineering leadership to reach an agreement on replacement terms. This will ensure that the product documentation will match the code.
+To ensure consistency and success, it is imperative for product team stakeholders to align internally.
+For example, documentation teams should engage in discussions with their engineering leadership to reach an agreement on replacement terms.
+This will ensure that the product documentation will match the code.
 
 When master refers to the main branch, our recommendation is to replace it with main.
 
@@ -53,9 +49,8 @@ If your project opts to use some other term or phrase, please [let us know](http
 
 ## Oh no! Slippery slope! Newspeak!
 
-We've heard concerns that this initiative
-puts us on a slippery slope to Newspeak portrayed in the 1984 dystopia
-by George Orwell. This initiative is completely different from Newspeak.
+We've heard concerns that this initiative puts us on a slippery slope to Newspeak portrayed in the 1984 dystopia by George Orwell.
+This initiative is completely different from Newspeak.
 Newspeak involved multiple changes but the most essential were:
 
  * Removing precise words in favor of general words so that it would become difficult to form precise thoughts
@@ -63,15 +58,12 @@ Newspeak involved multiple changes but the most essential were:
 
 Everything in the conscious language initiative is *the exact opposite* of that.
 
-For example, "Denylist" is both more precise and more accurate than "blacklist";
+For example, "denylist" is both more precise and more accurate than "blacklist".
 
 "Primary" is both more precise and more accurate than "master" in projects that have made that switch.
 
-The goal of this project is to use more precise words, in order to avoid
-unintended connotations that some common words and phrases have. Not
-only does this eliminate the hurt caused by those connotations, it also
-improves understanding, particularly for people who are reading in a
-second language, where those idioms may be confusing.
+The goal of this project is to use more precise words, in order to avoid unintended connotations that some common words and phrases have.
+Not only does this eliminate the hurt caused by those connotations, it also improves understanding, particularly for people who are reading in a second language, where those idioms may be confusing.
 
 ## How can I educate myself on why these terms are problematic?
 
@@ -80,7 +72,7 @@ Here are some resources on the topic:
  * [Welcoming Nomenclature](https://www.youtube.com/watch?v=hZuFeFuazwo) - Community Central presentation by Rich Bowen (Red Hat)
  * [Is It Enough To Remove Words With Racist Connotations From Tech Language? Hint: No](https://www.npr.org/2020/07/09/889502179/is-it-enough-to-remove-words-with-racist-connotations-from-tech-language-hint-no) - NPR interview with web developer Caroline Karanja
  * [Why is everything white?](https://www.bbc.com/news/av/world-us-canada-52988605/muhammad-ali-why-is-everything-white) (1971) - interview with Muhammed Ali
- * [That Word Black (2014)](http://mcwriting11.blogspot.com/2014/06/that-word-black-by-langston-hughes.html) - blog post by Langston Hughes
+ * [That Word Black (2014)](http://mcwriting11.blogspot.com/2014/06/that-word-black-by-langston-hughes.html) - by Langston Hughes
  * [Broken Metaphor: The Master-Slave Analogy in Technical Literature (2007)](https://www.jstor.org/stable/40061475?seq=1) - article in JSTOR, requires free membership to read
  * [Terminology, Power and Oppressive Language](https://tools.ietf.org/id/draft-knodel-terminology-00.html) - article with recommendations by Mallory Knodel and Niels ten Oever
  * [Why "master" matters](https://twitter.com/mislav/status/1270388510684598272) - A twitter thread.


### PR DESCRIPTION
As per #4, the idea here is to make it easier to copyedit and read the diffs in a collaborative document by putting each sentence on a line of its own. The paragraph remains in the rendering, but the source is easier to read and maintain.

Snuck in a few minor edits as well -- a punctuation consistency fix, capitalization fix, and making it clear that Langston Hughes did not author any blog posts. :)